### PR TITLE
Adds path.join

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,21 @@
 const path = require('path');
 const os = require('os');
 
-function locate() {
-  switch (os.type()) {
-      case 'Darwin':
-      return path.join(os.homedir(), "Library/Application Support/minecraft");
+let folder = "";
 
-      case 'win32':
-      case 'Windows_NT':
-      return path.join(require('user-settings-dir')(), ".minecraft");
+switch (os.type()) {
+    case 'Darwin':
+    folder = path.join(os.homedir(), '/Library/Application Support/minecraft');
+    break;
 
-      default:
-      return path.join(os.homedir(), ".minecraft");
-  }
+    case 'win32':
+    case 'Windows_NT':
+    folder = path.join(require('user-settings-dir')(), '.minecraft');
+    break;
+
+    default:
+    folder = path.join(os.homedir(), '.minecraft');
+    break;
 }
 
-module.exports = locate();
+module.exports = folder;

--- a/index.js
+++ b/index.js
@@ -1,20 +1,18 @@
+const path = require('path');
 const os = require('os');
 
-let folder = "";
+function locate() {
+  switch (os.type()) {
+      case 'Darwin':
+      return path.join(os.homedir(), "Library/Application Support/minecraft");
 
-switch (os.type()) {
-    case 'Darwin':
-    folder = os.homedir() + "/Library/Application Support/minecraft";
-    break;
+      case 'win32':
+      case 'Windows_NT':
+      return path.join(require('user-settings-dir')(), ".minecraft");
 
-    case 'win32':
-    case 'Windows_NT':
-    folder = require('user-settings-dir')() + ".minecraft";
-    break;
-
-    default:
-    folder = os.homedir() + "/.minecraft";
-    break;
+      default:
+      return path.join(os.homedir(), ".minecraft");
+  }
 }
 
-module.exports = folder;
+module.exports = locate();


### PR DESCRIPTION
On Windows 8.1, this package returned a path containing `AppData.minecraft`. Adding `path.join()` should only fix this bug without creating new ones.